### PR TITLE
背景で回転するモーフィングオブジェクトを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg"></canvas>
   <header>
     <h1>こんにちは GitHub Pages</h1>
     <nav>
@@ -37,6 +38,7 @@
   <footer>
     <p>&copy; 2024 My GitHub Pages</p>
   </footer>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -25,3 +25,70 @@ const showElement = () => {
 
 window.addEventListener("scroll", showElement);
 showElement();
+
+// 背景で回転するモーフィングオブジェクトの設定
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+const renderer = new THREE.WebGLRenderer({
+  canvas: document.getElementById("bg"),
+  alpha: true,
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const material = new THREE.MeshNormalMaterial();
+const geometries = [
+  new THREE.TetrahedronGeometry(1),
+  new THREE.BoxGeometry(1, 1, 1),
+  new THREE.SphereGeometry(0.9, 32, 32),
+];
+let currentIndex = 0;
+let mesh = new THREE.Mesh(geometries[currentIndex], material);
+scene.add(mesh);
+
+camera.position.z = 3;
+
+function animate() {
+  requestAnimationFrame(animate);
+  mesh.rotation.x += 0.01;
+  mesh.rotation.y += 0.01;
+  renderer.render(scene, camera);
+}
+animate();
+
+function morphShape() {
+  const nextIndex = (currentIndex + 1) % geometries.length;
+  const newMesh = new THREE.Mesh(geometries[nextIndex], material);
+  newMesh.scale.set(0.01, 0.01, 0.01);
+  scene.add(newMesh);
+
+  const start = performance.now();
+  const duration = 1000;
+
+  function transition(time) {
+    const t = Math.min((time - start) / duration, 1);
+    mesh.scale.set(1 - t, 1 - t, 1 - t);
+    newMesh.scale.set(t, t, t);
+    if (t < 1) {
+      requestAnimationFrame(transition);
+    } else {
+      scene.remove(mesh);
+      mesh = newMesh;
+      currentIndex = nextIndex;
+    }
+  }
+
+  requestAnimationFrame(transition);
+}
+
+setInterval(morphShape, 4000);
+
+window.addEventListener("resize", () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});

--- a/style.css
+++ b/style.css
@@ -6,6 +6,15 @@ body {
   background: #f5f5f5;
 }
 
+#bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
+
 header, main, footer {
   padding: 20px;
 }


### PR DESCRIPTION
## 概要
- three.js を導入し背景用のキャンバスを追加
- 三角形・立方体・球体を順にモーフィングする回転オブジェクトを実装

## テスト
- `npm test` を実行し package.json 不在による失敗を確認

------
https://chatgpt.com/codex/tasks/task_e_68aae4646668832a925bef60a8d2c539