### PR TITLE
Worksセクションのディスク表示とアニメーションの追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,16 @@
 
     <section id="works">
       <h2>Works</h2>
-      <ul>
-        <li>プロジェクトA — 実装がダルい</li>
-        <li>プロジェクトB — 実装がダルい</li>
-      </ul>
+      <div class="disc-list">
+        <div class="disc-item">
+          <img src="img/logo.png" alt="プロジェクトA 盤面" class="disc">
+          <img src="img/AlienChan.png" alt="プロジェクトA ジャケット" class="jacket">
+        </div>
+        <div class="disc-item">
+          <img src="img/logo.png" alt="プロジェクトB 盤面" class="disc">
+          <img src="img/me.jpg" alt="プロジェクトB ジャケット" class="jacket">
+        </div>
+      </div>
     </section>
 
     <section id="contact">

--- a/main.js
+++ b/main.js
@@ -129,3 +129,15 @@ if (CONFIG.PS1_MODE) {
   }
   animate();
 }
+
+// ===== Works: Disc Interaction =====
+document.querySelectorAll('#works .disc-item').forEach(item => {
+  item.addEventListener('click', () => {
+    if (item.classList.contains('open')) {
+      item.classList.remove('open');
+      return;
+    }
+    document.querySelectorAll('#works .disc-item.open').forEach(i => i.classList.remove('open'));
+    item.classList.add('open');
+  });
+});

--- a/style.css
+++ b/style.css
@@ -338,3 +338,42 @@ button:hover { background: #2f4fb7; }
   60%{transform: translate( 0.2px,-0.4px) rotate( 0.05deg)}
   80%{transform: translate( 0.5px,-0.2px) rotate( 0.06deg)}
 }
+
+/* ===============================
+   Works Discs
+   =============================== */
+#works .disc-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+#works .disc-item {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  cursor: pointer;
+}
+#works .disc-item img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+#works .disc-item img.disc {
+  border-radius: 50%;
+  transform: translateX(0) rotate(0deg);
+  z-index: 1;
+}
+#works .disc-item img.jacket {
+  z-index: 2;
+}
+#works .disc-item.open img.disc {
+  transform: translateX(110%) rotate(360deg);
+  z-index: 3;
+}
+#works .disc-item.open img.jacket {
+  transform: translateX(-20%);
+}


### PR DESCRIPTION
## 概要
- Worksセクションをディスク形式のレイアウトへ変更
- 盤面とジャケット画像を配置しクリックで盤面が前面に出る仕組みを実装
- positionとtransformを用いたアニメーションを追加

## テスト
- `npm test` を実行し、package.json 不在によるエラーを確認

------
https://chatgpt.com/codex/tasks/task_e_68ad91ba43e4832aa1855cb769e28c38