### PR TITLE
Works セクションの画像切替ギャラリーを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,15 @@
 
     <section id="works">
       <h2>Works</h2>
-      <ul>
-        <li>プロジェクトA — 実装がダルい</li>
-        <li>プロジェクトB — 実装がダルい</li>
-      </ul>
+      <div class="works-gallery">
+        <img id="work-preview" src="img/AlienChan.png" alt="プロジェクトA" />
+        <div class="work-thumbs">
+          <button class="work-thumb active" data-index="0" style="background-image: url('img/AlienChan.png');" aria-label="プロジェクトA"></button>
+          <button class="work-thumb" data-index="1" style="background-image: url('img/me.jpg');" aria-label="プロジェクトB"></button>
+          <button class="work-thumb" data-index="2" style="background-image: url('img/logo.png');" aria-label="プロジェクトC"></button>
+        </div>
+        <p id="work-description">プロジェクトA — 実装がダルい</p>
+      </div>
     </section>
 
     <section id="contact">
@@ -77,6 +82,7 @@
   }
   </script>
   <script type="module" src="./main.js"></script>
+  <script type="module" src="./works.js"></script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -117,6 +117,45 @@ button {
 button:hover { background: #2f4fb7; }
 
 /* ===============================
+   Works Section
+   =============================== */
+.works-gallery {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+#work-preview {
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+.work-thumbs {
+  display: flex;
+  gap: 8px;
+}
+
+.work-thumb {
+  width: 64px;
+  height: 64px;
+  appearance: none;
+  border: 2px solid var(--muted);
+  border-radius: 4px;
+  background-size: cover;
+  background-position: center;
+  cursor: pointer;
+}
+
+.work-thumb.active,
+.work-thumb:hover {
+  border-color: var(--accent);
+}
+
+/* ===============================
    Tabs (任意で使用)
    =============================== */
 .tabs {

--- a/works.js
+++ b/works.js
@@ -1,0 +1,21 @@
+const works = [
+  { image: 'img/AlienChan.png', description: 'プロジェクトA — 実装がダルい', alt: 'プロジェクトA' },
+  { image: 'img/me.jpg', description: 'プロジェクトB — 実装がダルい', alt: 'プロジェクトB' },
+  { image: 'img/logo.png', description: 'プロジェクトC — 実装がダルい', alt: 'プロジェクトC' }
+];
+
+const preview = document.getElementById('work-preview');
+const desc = document.getElementById('work-description');
+const thumbs = document.querySelectorAll('.work-thumb');
+
+thumbs.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const index = Number(btn.dataset.index);
+    const work = works[index];
+    preview.src = work.image;
+    preview.alt = work.alt;
+    desc.textContent = work.description;
+    thumbs.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+  });
+});


### PR DESCRIPTION
## 概要
- Works セクションにプレビュー画像とサムネイルを設置
- 作品サムネイルのクリックで対応する画像と説明を切り替え

## テスト
- `npm test` (package.json 不在により失敗)

------
https://chatgpt.com/codex/tasks/task_e_68ad94a1aff8832a8e8dc8f60bcd565e