### PR TITLE
粒子群モーフィングをサイト背景として描画

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,0 +1,30 @@
+import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
+import { createRenderer, fitToCanvas } from "./lib/renderer.js";
+import { createMorphPoints } from "./lib/morph.js";
+import { CONFIG } from "./lib/config.js";
+
+const canvas = document.getElementById("bg-canvas");
+const renderer = createRenderer(THREE, canvas, CONFIG);
+renderer.setClearColor(0x000000, 1);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+camera.position.set(0, 0, 0);
+
+const morph = createMorphPoints(THREE);
+scene.add(morph.points);
+
+function resize() {
+  fitToCanvas(renderer, canvas, CONFIG);
+  camera.aspect = canvas.clientWidth / canvas.clientHeight;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener("resize", resize);
+resize();
+
+function animate(time) {
+  requestAnimationFrame(animate);
+  morph.update(time);
+  renderer.render(scene, camera);
+}
+requestAnimationFrame(animate);

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 
 <body>
+  <canvas id="bg-canvas"></canvas>
   <header>
     <h1>Sunagimo の部屋</h1>
     <p class="tagline">ダルい</p>
@@ -76,6 +77,7 @@
     }
   }
   </script>
+  <script type="module" src="./bg.js"></script>
   <script type="module" src="./main.js"></script>
 </body>
 

--- a/lib/morph.js
+++ b/lib/morph.js
@@ -1,0 +1,96 @@
+export function createMorphPoints(THREE, count = 600){
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(count * 3);
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions,3));
+
+  const material = new THREE.PointsMaterial({ color: 0x888888, size: 0.05 });
+  const points = new THREE.Points(geometry, material);
+
+  // 形状ごとのターゲット座標を生成
+  const forms = [
+    generateTetra(),
+    generateCube(),
+    generateSphere()
+  ];
+  let current = 0;
+  let next = 1;
+  let start = performance.now();
+  const DURATION = 3000; // ms
+
+  function update(time){
+    const t = (time - start) / DURATION;
+    if(t >= 1){
+      start = time;
+      current = next;
+      next = (next + 1) % forms.length;
+    }
+    const k = Math.min(t,1);
+    for(let i=0;i<count;i++){
+      const a = forms[current][i];
+      const b = forms[next][i];
+      positions[i*3]   = THREE.MathUtils.lerp(a.x, b.x, k);
+      positions[i*3+1] = THREE.MathUtils.lerp(a.y, b.y, k);
+      positions[i*3+2] = THREE.MathUtils.lerp(a.z, b.z, k);
+    }
+    geometry.attributes.position.needsUpdate = true;
+  }
+
+  return { points, update };
+
+  function generateCube(){
+    const arr = [];
+    const SCALE = 8, Z_SHIFT = -20;
+    for(let i=0;i<count;i++){
+      const x = (Math.random()*2 - 1) * SCALE;
+      const y = (Math.random()*2 - 1) * SCALE;
+      const z = (Math.random()*2 - 1) * SCALE + Z_SHIFT;
+      arr.push(new THREE.Vector3(x,y,z));
+    }
+    return arr;
+  }
+
+  function generateSphere(){
+    const arr = [];
+    const R = 8, Z_SHIFT = -20;
+    for(let i=0;i<count;i++){
+      const u = Math.random();
+      const v = Math.random();
+      const theta = 2 * Math.PI * u;
+      const phi = Math.acos(2*v - 1);
+      const x = R * Math.sin(phi) * Math.cos(theta);
+      const y = R * Math.sin(phi) * Math.sin(theta);
+      const z = R * Math.cos(phi) + Z_SHIFT;
+      arr.push(new THREE.Vector3(x,y,z));
+    }
+    return arr;
+  }
+
+  function generateTetra(){
+    const arr = [];
+    const verts = [
+      new THREE.Vector3(1,1,1),
+      new THREE.Vector3(-1,-1,1),
+      new THREE.Vector3(-1,1,-1),
+      new THREE.Vector3(1,-1,-1)
+    ];
+    const SCALE = 8, Z_SHIFT = -20;
+    for(let i=0;i<count;i++){
+      let r1 = Math.random();
+      let r2 = Math.random();
+      let r3 = Math.random();
+      if(r1 + r2 + r3 > 1){
+        r1 = 1 - r1;
+        r2 = 1 - r2;
+        r3 = 1 - r3;
+      }
+      const p = new THREE.Vector3().copy(verts[0])
+        .addScaledVector(verts[1].clone().sub(verts[0]), r1)
+        .addScaledVector(verts[2].clone().sub(verts[0]), r2)
+        .addScaledVector(verts[3].clone().sub(verts[0]), r3);
+      p.multiplyScalar(SCALE/2); // 調整
+      p.z += Z_SHIFT;
+      arr.push(p);
+    }
+    return arr;
+  }
+}

--- a/main.js
+++ b/main.js
@@ -121,11 +121,11 @@ if (CONFIG.PS1_MODE) {
   }
   requestAnimationFrame(loop);
 } else {
-  function animate(){
+  function animate(time){
     requestAnimationFrame(animate);
     cube.rotation.y += 0.007;
     renderer.render(scene, camera); // 直接描画
     controls.update();
   }
-  animate();
+  requestAnimationFrame(animate);
 }

--- a/style.css
+++ b/style.css
@@ -22,6 +22,17 @@ body {
   color: var(--text);
 }
 
+#bg-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  z-index: -1;
+  pointer-events: none;
+}
+
 /* 見出しなど */
 h1 { color: var(--accent); }
 section h2 {


### PR DESCRIPTION
## 概要
- サイト全体を覆う `bg-canvas` を追加し、粒子群が三角錐→立方体→球体へループ変形する背景を実装
- 既存のアバター用シーンから粒子背景処理を分離

## テスト
- `node --check lib/morph.js`
- `node --check bg.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad9fb74880832aa74dd3d9a38caa4e