### PR TITLE
Works セクションにタブ切り替えとカルーセルを実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,21 @@
 
     <section id="works">
       <h2>Works</h2>
-      <ul>
-        <li>プロジェクトA — 実装がダルい</li>
-        <li>プロジェクトB — 実装がダルい</li>
-      </ul>
+      <div class="works-tabs">
+        <button type="button" class="active" data-category="game">Game</button>
+        <button type="button" data-category="tool">Tool</button>
+        <button type="button" data-category="other">Other</button>
+      </div>
+      <div class="works-view">
+        <button type="button" class="arrow arrow-left" aria-label="前へ"></button>
+        <div class="works-content">
+          <div class="works-image">
+            <img src="" alt="">
+          </div>
+          <ul class="works-desc"></ul>
+        </div>
+        <button type="button" class="arrow arrow-right" aria-label="次へ"></button>
+      </div>
     </section>
 
     <section id="contact">
@@ -79,6 +90,7 @@
   </script>
   <script type="module" src="./main.js"></script>
   <script type="module" src="./bg.js"></script>
+  <script type="module" src="./works.js"></script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -100,6 +100,80 @@ header {
 }
 
 /* ===============================
+   Works
+   =============================== */
+#works {
+  position: relative;
+}
+.works-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.works-tabs button {
+  background: var(--card);
+  color: var(--text);
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.works-tabs button.active {
+  background: #333;
+  color: #fff;
+}
+.works-view {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.arrow {
+  width: 0;
+  height: 0;
+  border-top: 20px solid transparent;
+  border-bottom: 20px solid transparent;
+  cursor: pointer;
+  background: none;
+  border-left: none;
+  border-right: none;
+  padding: 0;
+}
+.arrow-left {
+  border-right: 20px solid var(--text);
+}
+.arrow-right {
+  border-left: 20px solid var(--text);
+}
+.works-content {
+  background: var(--card);
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 600px;
+  width: 100%;
+}
+.works-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-height: 300px;
+}
+.works-image img {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+  width: auto;
+  object-fit: contain;
+}
+.works-desc {
+  margin-top: 8px;
+}
+
+/* ===============================
    Footer
    =============================== */
 footer {

--- a/works.js
+++ b/works.js
@@ -1,0 +1,97 @@
+const WORKS = {
+  game: [
+    {
+      src: 'img/AlienChan.png',
+      alt: 'AlienChan',
+      desc: [
+        'ゲーム作品1の説明です',
+        'ここに説明を記述する',
+        'ここに説明を記述する',
+        'ここに説明を記述する'
+      ]
+    },
+    {
+      src: 'img/me.jpg',
+      alt: 'me',
+      desc: [
+        'ゲーム作品2の説明です',
+        'ここに説明を記述する'
+      ]
+    }
+  ],
+  tool: [
+    {
+      src: 'img/logo.png',
+      alt: 'ロゴ',
+      desc: [
+        'ツール作品1の説明です',
+        'ここに説明を記述する'
+      ]
+    }
+  ],
+  other: [
+    {
+      src: 'img/AlienChan.png',
+      alt: 'AlienChan',
+      desc: [
+        'その他作品の説明です',
+        'ここに説明を記述する'
+      ]
+    }
+  ]
+};
+
+const tabs = document.querySelectorAll('.works-tabs button');
+const image = document.querySelector('.works-image img');
+const descList = document.querySelector('.works-desc');
+const left = document.querySelector('.arrow-left');
+const right = document.querySelector('.arrow-right');
+
+let currentCategory = 'game';
+let index = 0;
+
+function render() {
+  const list = WORKS[currentCategory] || [];
+  if (list.length === 0) {
+    image.style.display = 'none';
+    descList.innerHTML = '<li>作品がありません</li>';
+    return;
+  }
+  image.style.display = '';
+  index = (index + list.length) % list.length;
+  const item = list[index];
+  image.src = item.src;
+  image.alt = item.alt || '';
+  descList.innerHTML = '';
+  item.desc.forEach((line) => {
+    const li = document.createElement('li');
+    li.textContent = line;
+    descList.appendChild(li);
+  });
+}
+
+tabs.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    tabs.forEach((b) => b.classList.remove('active'));
+    btn.classList.add('active');
+    currentCategory = btn.dataset.category;
+    index = 0;
+    render();
+  });
+});
+
+left.addEventListener('click', () => {
+  const list = WORKS[currentCategory] || [];
+  if (list.length === 0) return;
+  index = (index - 1 + list.length) % list.length;
+  render();
+});
+
+right.addEventListener('click', () => {
+  const list = WORKS[currentCategory] || [];
+  if (list.length === 0) return;
+  index = (index + 1) % list.length;
+  render();
+});
+
+render();


### PR DESCRIPTION
## 概要
- Works セクションに Game/Tool/Other のタブを追加
- 作品を左右の三角形で切り替えられるカルーセルを実装
- 画像をコンテナ内で自然な大きさに表示

## テスト
- `npm test`（package.json 不存在のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68ae7ee81144832abfd3a3a49d92c1d8