### PR TITLE
各スクリプトへのコメント追加

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,5 +1,7 @@
-// 背景：立方体内で球が跳ねあう（壁＆球-球の弾性衝突）
-// 既存の #bg-canvas を使用。Boids は撤去してOK。
+// bg.js
+// 背景アニメーション：立方体内で球が跳ね回るシンプルなデモ
+// - 既存の #bg-canvas 要素へ描画
+// - 壁との反射と球同士の弾性衝突を実装
 
 import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
 
@@ -92,7 +94,10 @@ for (let i = 0; i < COUNT; i++) {
   vel[i3 + 2] = rand(-1.0, 1.0);
 }
 
-// 壁反射（完全弾性）
+/**
+ * 壁との衝突を処理し、侵入分を押し戻して完全弾性反射させる。
+ * @param {number} i3 pos/vel 配列の開始インデックス
+ */
 function reflectWalls(i3) {
   // 位置更新後に壁で反射。侵入した分は押し戻す。
   for (let axis = 0; axis < 3; axis++) {
@@ -104,7 +109,10 @@ function reflectWalls(i3) {
   }
 }
 
-// 球-球の弾性衝突（同質量の簡易モデル）
+/**
+ * 球同士の弾性衝突を処理する（同質量の近似モデル）。
+ * @param {number} dt 更新ステップ秒
+ */
 function collidePairs(dt) {
   const minDist = 2 * R;
   const minDist2 = minDist * minDist;
@@ -157,6 +165,9 @@ function collidePairs(dt) {
 
 // InstancedMesh へ座標を反映
 const dummy = new THREE.Object3D();
+/**
+ * 計算済みの座標を InstancedMesh へ書き戻す。
+ */
 function syncInstances() {
   for (let i = 0; i < COUNT; i++) {
     const i3 = i * 3;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,12 +1,14 @@
+// lib/config.js
+// PS1 風レンダリングのための各種設定値
 export const CONFIG = {
-  PS1_MODE: true,
-  AFFINE_STRENGTH: 0.65,
-  INTERNAL_SCALE: 0.5,   // PS1時の内部解像度倍率
-  FIXED_FPS: 30,
-  RGB_BITS: 3,
+  PS1_MODE: true,         // PS1 表現を有効にするか
+  AFFINE_STRENGTH: 0.65,  // アフィン補間の強さ 0.0〜1.0
+  INTERNAL_SCALE: 0.5,    // 内部レンダリング解像度倍率
+  FIXED_FPS: 30,          // 固定ステップのFPS
+  RGB_BITS: 3,            // 減色時のRGB各チャネルビット数
 
-  //色収差（Chromatic Aberration）
-  CA_ENABLED: true,
-  CA_STRENGTH: 50, // 強さ（0.3〜1.2 目安）
-  CA_POWER: 2.25      // 端ほど強くする増幅の指数（1.5〜2.5）
+  // 色収差（Chromatic Aberration）
+  CA_ENABLED: true,       // 色収差を有効化
+  CA_STRENGTH: 50,        // 色ずれの強さ（0.3〜1.2 目安）
+  CA_POWER: 2.25          // 端ほど強くする増幅の指数（1.5〜2.5）
 };

--- a/lib/controls.js
+++ b/lib/controls.js
@@ -1,4 +1,15 @@
+// lib/controls.js
+// OrbitControls を薄くラップし、ズームやパンを禁止する
 import { OrbitControls } from "https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js";
+
+/**
+ * マウス操作用の OrbitControls を生成。
+ * @param {typeof import('three')} THREE three 名前空間
+ * @param {THREE.Camera} camera 操作対象カメラ
+ * @param {HTMLElement} dom 入力を受け付けるDOM
+ * @param {object} cfg 設定値（未使用だが統一のため渡す）
+ * @returns {OrbitControls}
+ */
 export function createControls(THREE, camera, dom, cfg){
   const controls = new OrbitControls(camera, dom);
   controls.enableZoom = false;

--- a/lib/postprocess.js
+++ b/lib/postprocess.js
@@ -1,3 +1,13 @@
+// lib/postprocess.js
+// 減色ディザと色収差を行うポストプロセスパイプライン
+/**
+ * ポストプロセスパイプラインを生成。
+ * PS1_MODE なら減色ディザと色収差を適用し、無効なら素通し。
+ * @param {typeof import('three')} THREE three 名前空間
+ * @param {THREE.WebGLRenderer} renderer ベースレンダラー
+ * @param {object} cfg 設定値
+ * @returns {{render:(s:THREE.Scene,c:THREE.Camera)=>void, resize:(r:THREE.WebGLRenderer)=>void}}
+ */
 export function createPostPipeline(THREE, renderer, cfg){
   if (!cfg.PS1_MODE){
     // PS1モードでないときはポスト無しでそのまま描画

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,9 +1,25 @@
+// lib/renderer.js
+// レンダラー生成とキャンバスサイズ合わせ処理
+/**
+ * WebGLRenderer を初期化。
+ * @param {typeof import('three')} THREE three 名前空間
+ * @param {HTMLCanvasElement} canvas 描画先キャンバス
+ * @param {object} cfg 設定値
+ * @returns {THREE.WebGLRenderer}
+ */
 export function createRenderer(THREE, canvas, cfg){
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   fitToCanvas(renderer, canvas, cfg);
   return renderer;
 }
+
+/**
+ * Canvas の見た目サイズに合わせてレンダラーを調整。
+ * @param {THREE.WebGLRenderer} renderer 対象レンダラー
+ * @param {HTMLCanvasElement} canvas 対象キャンバス
+ * @param {object} cfg 設定値
+ */
 export function fitToCanvas(renderer, canvas, cfg){
   const rect = canvas.getBoundingClientRect();
   const w = Math.max(1, rect.width|0);

--- a/lib/scene.js
+++ b/lib/scene.js
@@ -1,4 +1,13 @@
+// lib/scene.js
+// シーングラフの生成：テクスチャ付き立方体を配置
 import { makeAffineMaterial, makePerspMaterial } from "./materials.js";
+
+/**
+ * シーン・カメラ・メッシュを構築して返す。
+ * @param {typeof import('three')} THREE three 名前空間
+ * @param {object} cfg 設定値
+ * @returns {{scene:THREE.Scene,camera:THREE.PerspectiveCamera,cube:THREE.Mesh}}
+ */
 export function createSceneGraph(THREE, cfg){
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,20 @@
+// lib/utils.js
+// PS1 風のジッター処理など補助関数群
+/**
+ * 値を指定ステップで丸める。
+ * @param {number} v 対象値
+ * @param {number} step 丸め単位
+ * @returns {number} 丸め後の値
+ */
 function snap(v, step){ return Math.round(v/step)*step; }
+
+/**
+ * カメラとオブジェクトに量子化ジッターを適用し、PS1 風の粗さを再現。
+ * @param {typeof import('three')} THREE three 名前空間
+ * @param {THREE.Camera} camera 対象カメラ
+ * @param {THREE.Object3D} cube 対象オブジェクト
+ * @param {object} cfg 設定値
+ */
 export function applyPS1Jitter(THREE, camera, cube, cfg){
   if(!cfg.PS1_MODE) return;
   const posStep = 1/256;

--- a/main.js
+++ b/main.js
@@ -1,3 +1,7 @@
+// main.js
+// three.js アバター表示のエントリーポイント
+// - レンダラー・シーングラフ・操作系・ポスト処理を初期化
+// - ブートオーバーレイとリサイズ処理を管理
 import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
 import { createRenderer, fitToCanvas } from "./lib/renderer.js";
 import { createSceneGraph } from "./lib/scene.js";
@@ -93,7 +97,9 @@ const post = createPostPipeline(THREE, renderer, CONFIG); // { render(scene,came
   overlay.addEventListener('click', (e)=>{ if(e.target === overlay) closeOverlay(); });
 })();
 
-
+/**
+ * Canvas サイズに合わせてレンダラー・ポスト処理・カメラを調整。
+ */
 function resize() {
   fitToCanvas(renderer, canvas, CONFIG);
   post.resize(renderer);

--- a/works.js
+++ b/works.js
@@ -1,3 +1,6 @@
+// works.js
+// 制作物ギャラリーのタブ切替と表示処理
+// - WORKS 定義に従い画像と説明を更新
 const WORKS = {
   game: [
     {
@@ -48,6 +51,9 @@ const right = document.querySelector('.arrow-right');
 let currentCategory = 'game';
 let index = 0;
 
+/**
+ * 現在のカテゴリから作品を1件選んで表示する。
+ */
 function render() {
   const list = WORKS[currentCategory] || [];
   if (list.length === 0) {


### PR DESCRIPTION
## 概要
- materials.js のスタイルに倣い、全スクリプトへ概要コメントと JSDoc を付与
- 設定値やユーティリティ関数の用途を明示し、保守性を向上

## テスト
- `npm test`：package.json が存在せず実行不可

------
https://chatgpt.com/codex/tasks/task_e_68ae89037be0832ab54291e246748b11