### PR TITLE
固定ステップループを共通化する

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,3 +28,63 @@ export function applyPS1Jitter(THREE, camera, cube, cfg)
   cube.rotation.y = snap(cube.rotation.y, rotStep);
   cube.rotation.z = snap(cube.rotation.z, rotStep);
 }
+
+/**
+ * 固定ステップのループを開始し、タブの可視状態に応じて停止・再開する。
+ * @param {number} stepMs 1 ステップ当たりのミリ秒（0 なら可変）
+ * @param {(dtSec:number) => void} update 更新処理
+ * @param {() => void} render 描画処理
+ * @returns {{ start: () => void, stop: () => void }} 制御関数
+ */
+export function runFixedStepLoop(stepMs, update, render)
+{
+  let raf = 0;
+  let acc = 0;
+  let last = 0;
+
+  function frame(now)
+  {
+    raf = requestAnimationFrame(frame);
+    const delta = now - last;
+    last = now;
+
+    if (stepMs > 0)
+    {
+      acc += delta;
+      while (acc >= stepMs)
+      {
+        update(stepMs / 1000);
+        acc -= stepMs;
+      }
+    }
+    else
+    {
+      update(delta / 1000);
+    }
+
+    render();
+  }
+
+  function start()
+  {
+    last = performance.now();
+    acc = 0;
+    raf = requestAnimationFrame(frame);
+  }
+
+  function stop()
+  {
+    cancelAnimationFrame(raf);
+  }
+
+  document.addEventListener('visibilitychange', () =>
+  {
+    if (document.visibilityState === 'hidden')
+      stop();
+    else
+      start();
+  });
+
+  start();
+  return { start, stop };
+}


### PR DESCRIPTION
## 概要
- runFixedStepLoop を追加して固定ステップのループ処理を共通化
- bg.js と main.js のループを共通関数に置き換え
- visibilitychange ハンドラを共通化してタブ非表示時に停止するよう改善

## テスト
- `npm test` : package.json が無いため実行不可

------
https://chatgpt.com/codex/tasks/task_e_68aea470a09c832abb87625089163923