### PR TITLE
シェーダーマテリアル生成ユーティリティの共通化

### DIFF
--- a/lib/materials.js
+++ b/lib/materials.js
@@ -1,11 +1,28 @@
 // lib/materials.js
 // three.js 用マテリアル生成ユーティリティ
+// - createShaderMaterial: 共通オプションをまとめたラッパー
 // - makeAffineMaterial: 透視補正を外した“擬似アフィン”なUV補間（PS1風の床がにゅるっと伸びる歪み）
 // - makePerspMaterial: 通常の透視補正（標準的な描画）
 //
 // 使い方：scene.js 側などで
 //   import { makeAffineMaterial, makePerspMaterial } from "./materials.js";
 //   const mat = makeAffineMaterial(THREE, texture, 0.65, /*toGray=*/false);
+
+/**
+ * ShaderMaterial を生成する共通ラッパー
+ * @param {typeof import('three')} THREE - three 名前空間
+ * @param {THREE.ShaderMaterialParameters} options - ShaderMaterial のパラメータ
+ * @returns {THREE.ShaderMaterial}
+ */
+export function createShaderMaterial(THREE, options)
+{
+  return new THREE.ShaderMaterial({
+    transparent: false,
+    depthTest: true,
+    depthWrite: true,
+    ...options
+  });
+}
 
 /**
  * アフィン歪みシェーダ（擬似）
@@ -17,12 +34,7 @@
  */
 export function makeAffineMaterial(THREE, map, affineStrength, toGray = false)
 {
-  return new THREE.ShaderMaterial({
-    uniforms: {
-      map: { value: map },
-      uAffine: { value: affineStrength }
-    },
-    vertexShader: `
+  const vertexShader = `
       varying vec2 vUv_persp;     // 透視補正ありUV
       varying vec2 vUv_affineRaw; // アフィン用に w を掛けたUV
       varying float vFragW;       // クリップ後の w（frag側で割り戻し）
@@ -36,8 +48,8 @@ export function makeAffineMaterial(THREE, map, affineStrength, toGray = false)
 
         gl_Position = clip;
       }
-    `,
-    fragmentShader: `
+    `;
+  const fragmentShader = `
       precision mediump float;
       uniform sampler2D map;
       uniform float uAffine;
@@ -65,10 +77,15 @@ export function makeAffineMaterial(THREE, map, affineStrength, toGray = false)
           gl_FragColor = c;
         `}
       }
-    `,
-    transparent: false,
-    depthTest: true,
-    depthWrite: true
+    `;
+  const uniforms = {
+    map: { value: map },
+    uAffine: { value: affineStrength }
+  };
+  return createShaderMaterial(THREE, {
+    uniforms,
+    vertexShader,
+    fragmentShader
   });
 }
 
@@ -81,16 +98,14 @@ export function makeAffineMaterial(THREE, map, affineStrength, toGray = false)
  */
 export function makePerspMaterial(THREE, map, toGray = false)
 {
-  return new THREE.ShaderMaterial({
-    uniforms: { map: { value: map } },
-    vertexShader: `
+  const vertexShader = `
       varying vec2 vUv;
       void main() {
         vUv = uv; // three が自動で透視補正補間してくれる
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
       }
-    `,
-    fragmentShader: `
+    `;
+  const fragmentShader = `
       precision mediump float;
       uniform sampler2D map;
       varying vec2 vUv;
@@ -103,9 +118,11 @@ export function makePerspMaterial(THREE, map, toGray = false)
           gl_FragColor = c;
         `}
       }
-    `,
-    transparent: false,
-    depthTest: true,
-    depthWrite: true
+    `;
+  const uniforms = { map: { value: map } };
+  return createShaderMaterial(THREE, {
+    uniforms,
+    vertexShader,
+    fragmentShader
   });
 }


### PR DESCRIPTION
## 概要
- ShaderMaterial の共通オプションを集約する `createShaderMaterial` を追加
- `makeAffineMaterial` と `makePerspMaterial` を共通ラッパー経由の実装に整理

## テスト
- `node -e "require('./lib/materials.js')"`
- `npm test` : package.json が存在せず実行不可

------
https://chatgpt.com/codex/tasks/task_e_68aeaa1eb544832a902f73e79cf4ba2c