### PR TITLE
背景物理モジュールの追加とレンダリングコードの分離

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -6,6 +6,7 @@
 import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
 import { createRenderer, fitToCanvas } from "./lib/renderer.js";
 import { runFixedStepLoop } from "./lib/utils.js";
+import { BgPhysics } from "./lib/bgPhysics.js";
 
 const canvas = document.getElementById("bg-canvas");
 if (!canvas)
@@ -34,202 +35,53 @@ const amb = new THREE.AmbientLight(0xffffff, 0.5);
 const dir = new THREE.DirectionalLight(0xffffff, 0.6);
 dir.position.set(1, 2, 3);
 scene.add(amb, dir);
+ 
+// -------- 設定 --------
+const physicsCfg = {
+  bounds: 4.0, // 立方体の一辺
+  count: 24, // 球の数（20〜40くらいが見栄えと負荷のバランス◎）
+  radius: 0.1, // 半径
+  speed: 0.1, // 速度スケール
+};
 
 // -------- 立方体ワイヤーフレーム（枠） --------
-const BOUNDS = 4.0; // 立方体の一辺
-const half = BOUNDS / 2;
-const boxGeo = new THREE.BoxGeometry(BOUNDS, BOUNDS, BOUNDS);
+const boxGeo = new THREE.BoxGeometry(physicsCfg.bounds, physicsCfg.bounds, physicsCfg.bounds);
 const edges = new THREE.EdgesGeometry(boxGeo);
 const lineMat = new THREE.LineBasicMaterial({ color: 0x666666, transparent: true, opacity: 0.7 });
 const box = new THREE.LineSegments(edges, lineMat);
 scene.add(box);
-
+ 
 // -------- 球（InstancedMesh で高速＆省メモリ） --------
-const COUNT = 24; // 球の数（20〜40くらいが見栄えと負荷のバランス◎）
-const R = 0.1; // 半径
-const GEO = new THREE.SphereGeometry(R, 16, 12); // 低ポリ
+const GEO = new THREE.SphereGeometry(physicsCfg.radius, 16, 12); // 低ポリ
 // ※色は固定。減色やランダム色にしたければ THREE.InstancedMesh#setColorAt を使う
 const MAT = new THREE.MeshStandardMaterial({
   color: 0xffffff,
   metalness: 0.1,
   roughness: 0.6,
 });
-const BALLS = new THREE.InstancedMesh(GEO, MAT, COUNT);
+const BALLS = new THREE.InstancedMesh(GEO, MAT, physicsCfg.count);
 BALLS.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 scene.add(BALLS);
 
-// 位置・速度（XYZ をフラット配列で管理）
-const pos = new Float32Array(COUNT * 3);
-const vel = new Float32Array(COUNT * 3);
-
-// 初期化：重なりを避けつつランダム配置
-function rand(min, max) { return min + Math.random() * (max - min); }
-for (let i = 0; i < COUNT; i++)
-{
-  // 位置
-  let placed = false;
-  let px = 0, py = 0, pz = 0;
-  while (!placed)
-  {
-    px = rand(-half + R, half - R);
-    py = rand(-half + R, half - R);
-    pz = rand(-half + R, half - R);
-    placed = true;
-    for (let j = 0; j < i; j++)
-    {
-      const j3 = j * 3;
-      const dx = px - pos[j3 + 0];
-      const dy = py - pos[j3 + 1];
-      const dz = pz - pos[j3 + 2];
-      if (dx * dx + dy * dy + dz * dz < (2 * R) * (2 * R))
-      {
-        placed = false;
-        break;
-      }
-    }
-  }
-  const i3 = i * 3;
-  pos[i3 + 0] = px;
-  pos[i3 + 1] = py;
-  pos[i3 + 2] = pz;
-
-  // 速度（ほどよい速度で）
-  vel[i3 + 0] = rand(-1.0, 1.0);
-  vel[i3 + 1] = rand(-1.0, 1.0);
-  vel[i3 + 2] = rand(-1.0, 1.0);
-}
-
-/**
- * 壁との衝突を処理し、侵入分を押し戻して完全弾性反射させる。
- * @param {number} i3 pos/vel 配列の開始インデックス
- */
-function reflectWalls(i3)
-{
-  // 位置更新後に壁で反射。侵入した分は押し戻す。
-  for (let axis = 0; axis < 3; axis++)
-  {
-    const p = pos[i3 + axis];
-    const v = vel[i3 + axis];
-    const limit = half - R;
-    if (p > limit)
-    {
-      pos[i3 + axis] = limit;
-      vel[i3 + axis] = -Math.abs(v);
-    }
-    else if (p < -limit)
-    {
-      pos[i3 + axis] = -limit;
-      vel[i3 + axis] = Math.abs(v);
-    }
-  }
-}
-
-/**
- * 球同士の弾性衝突を処理する（同質量の近似モデル）。
- * @param {number} dt 更新ステップ秒
- */
-function collidePairs(dt)
-{
-  const minDist = 2 * R;
-  const minDist2 = minDist * minDist;
-  for (let i = 0; i < COUNT; i++)
-  {
-    const i3 = i * 3;
-    const ix = pos[i3], iy = pos[i3 + 1], iz = pos[i3 + 2];
-    for (let j = i + 1; j < COUNT; j++)
-    {
-      const j3 = j * 3;
-      const dx = pos[j3] - ix;
-      const dy = pos[j3 + 1] - iy;
-      const dz = pos[j3 + 2] - iz;
-      const d2 = dx * dx + dy * dy + dz * dz;
-      if (d2 < minDist2 && d2 > 1e-9)
-      {
-        const d = Math.sqrt(d2);
-        // 法線
-        const nx = dx / d, ny = dy / d, nz = dz / d;
-
-        // オーバーラップ分を押し戻す（半分ずつ）
-        const overlap = (minDist - d);
-        const push = overlap * 0.5 + 1e-4; // 少し余裕を持たせる
-        pos[i3] -= nx * push;
-        pos[i3 + 1] -= ny * push;
-        pos[i3 + 2] -= nz * push;
-        pos[j3] += nx * push;
-        pos[j3 + 1] += ny * push;
-        pos[j3 + 2] += nz * push;
-
-        // 速度の法線成分を交換（同質量・完全弾性の近似）
-        const vin = vel[i3] * nx + vel[i3 + 1] * ny + vel[i3 + 2] * nz;
-        const vjn = vel[j3] * nx + vel[j3 + 1] * ny + vel[j3 + 2] * nz;
-
-        const ivx = vel[i3] - vin * nx;
-        const ivy = vel[i3 + 1] - vin * ny;
-        const ivz = vel[i3 + 2] - vin * nz;
-        const jvx = vel[j3] - vjn * nx;
-        const jvy = vel[j3 + 1] - vjn * ny;
-        const jvz = vel[j3 + 2] - vjn * nz;
-
-        // 法線成分を入れ替え
-        vel[i3] = ivx + vjn * nx;
-        vel[i3 + 1] = ivy + vjn * ny;
-        vel[i3 + 2] = ivz + vjn * nz;
-        vel[j3] = jvx + vin * nx;
-        vel[j3 + 1] = jvy + vin * ny;
-        vel[j3 + 2] = jvz + vin * nz;
-      }
-    }
-  }
-}
-
-// InstancedMesh へ座標を反映
-const dummy = new THREE.Object3D();
-/**
- * 計算済みの座標を InstancedMesh へ書き戻す。
- */
-function syncInstances()
-{
-  for (let i = 0; i < COUNT; i++)
-  {
-    const i3 = i * 3;
-    dummy.position.set(pos[i3], pos[i3 + 1], pos[i3 + 2]);
-    // ほんの少し回しておくと見栄えが良い（任意）
-    dummy.rotation.y += 0.01;
-    dummy.updateMatrix();
-    BALLS.setMatrixAt(i, dummy.matrix);
-  }
-  BALLS.instanceMatrix.needsUpdate = true;
-}
+// -------- 物理 --------
+const physics = new BgPhysics(THREE, BALLS, physicsCfg);
 
 // -------- ループ（固定ステップ 20fps / 軽量） --------
 const STEP = 1000 / 20; // 20fps
-const SPEED = 0.1; // 速度スケール（好みで）
 runFixedStepLoop(
   STEP,
   (dt) =>
   {
-    const dtScaled = dt * SPEED;
-
     // 立方体の回転
     box.rotation.x += 0.0008;
     box.rotation.y -= 0.0012;
 
-    // 球体の位置更新
-    for (let i = 0; i < COUNT; i++)
-    {
-      const i3 = i * 3;
-      pos[i3] += vel[i3] * dtScaled;
-      pos[i3 + 1] += vel[i3 + 1] * dtScaled;
-      pos[i3 + 2] += vel[i3 + 2] * dtScaled;
-      reflectWalls(i3);
-    }
-
-    // 球-球衝突
-    collidePairs(dtScaled);
+    // 物理更新
+    physics.step(dt);
   },
   () =>
   {
-    syncInstances();
+    physics.sync();
     renderer.render(scene, camera);
   }
 );

--- a/lib/bgPhysics.js
+++ b/lib/bgPhysics.js
@@ -1,0 +1,170 @@
+/**
+ * 背景用の球体物理シミュレーション。
+ * 球の位置更新と衝突判定を担当する。
+ */
+export class BgPhysics {
+  /**
+   * @param {object} THREE three.js モジュール
+   * @param {import('three').InstancedMesh} mesh 座標を書き込むインスタンスメッシュ
+   * @param {object} cfg 設定
+   * @param {number} cfg.count 球の数
+   * @param {number} cfg.bounds 立方体の一辺
+   * @param {number} cfg.radius 球の半径
+   * @param {number} cfg.speed 速度スケール
+   */
+  constructor(THREE, mesh, cfg)
+  {
+    this.THREE = THREE;
+    this.mesh = mesh;
+    this.count = cfg.count;
+    this.bounds = cfg.bounds;
+    this.radius = cfg.radius;
+    this.speed = cfg.speed;
+    this.half = this.bounds / 2;
+
+    this.pos = new Float32Array(this.count * 3);
+    this.vel = new Float32Array(this.count * 3);
+    this._dummy = new THREE.Object3D();
+
+    this._init();
+  }
+
+  /** 初期配置と速度をランダムに設定する。 */
+  _init()
+  {
+    const rand = (min, max) => min + Math.random() * (max - min);
+    const r = this.radius;
+    const half = this.half;
+    for (let i = 0; i < this.count; i++)
+    {
+      let placed = false;
+      let px = 0, py = 0, pz = 0;
+      while (!placed)
+      {
+        px = rand(-half + r, half - r);
+        py = rand(-half + r, half - r);
+        pz = rand(-half + r, half - r);
+        placed = true;
+        for (let j = 0; j < i; j++)
+        {
+          const j3 = j * 3;
+          const dx = px - this.pos[j3 + 0];
+          const dy = py - this.pos[j3 + 1];
+          const dz = pz - this.pos[j3 + 2];
+          if (dx * dx + dy * dy + dz * dz < (2 * r) * (2 * r))
+          {
+            placed = false;
+            break;
+          }
+        }
+      }
+      const i3 = i * 3;
+      this.pos[i3 + 0] = px;
+      this.pos[i3 + 1] = py;
+      this.pos[i3 + 2] = pz;
+      this.vel[i3 + 0] = rand(-1.0, 1.0);
+      this.vel[i3 + 1] = rand(-1.0, 1.0);
+      this.vel[i3 + 2] = rand(-1.0, 1.0);
+    }
+  }
+
+  /** 指定インデックスの球と壁との衝突を処理する。 */
+  _reflect(i3)
+  {
+    const limit = this.half - this.radius;
+    for (let axis = 0; axis < 3; axis++)
+    {
+      const p = this.pos[i3 + axis];
+      const v = this.vel[i3 + axis];
+      if (p > limit)
+      {
+        this.pos[i3 + axis] = limit;
+        this.vel[i3 + axis] = -Math.abs(v);
+      }
+      else if (p < -limit)
+      {
+        this.pos[i3 + axis] = -limit;
+        this.vel[i3 + axis] = Math.abs(v);
+      }
+    }
+  }
+
+  /** 球同士の衝突を処理する。 */
+  _collide()
+  {
+    const r2 = (2 * this.radius) * (2 * this.radius);
+    for (let i = 0; i < this.count; i++)
+    {
+      const i3 = i * 3;
+      const ix = this.pos[i3], iy = this.pos[i3 + 1], iz = this.pos[i3 + 2];
+      for (let j = i + 1; j < this.count; j++)
+      {
+        const j3 = j * 3;
+        const dx = this.pos[j3] - ix;
+        const dy = this.pos[j3 + 1] - iy;
+        const dz = this.pos[j3 + 2] - iz;
+        const d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 < r2 && d2 > 1e-9)
+        {
+          const d = Math.sqrt(d2);
+          const nx = dx / d, ny = dy / d, nz = dz / d;
+          const overlap = (2 * this.radius - d);
+          const push = overlap * 0.5 + 1e-4;
+          this.pos[i3] -= nx * push;
+          this.pos[i3 + 1] -= ny * push;
+          this.pos[i3 + 2] -= nz * push;
+          this.pos[j3] += nx * push;
+          this.pos[j3 + 1] += ny * push;
+          this.pos[j3 + 2] += nz * push;
+
+          const vin = this.vel[i3] * nx + this.vel[i3 + 1] * ny + this.vel[i3 + 2] * nz;
+          const vjn = this.vel[j3] * nx + this.vel[j3 + 1] * ny + this.vel[j3 + 2] * nz;
+
+          const ivx = this.vel[i3] - vin * nx;
+          const ivy = this.vel[i3 + 1] - vin * ny;
+          const ivz = this.vel[i3 + 2] - vin * nz;
+          const jvx = this.vel[j3] - vjn * nx;
+          const jvy = this.vel[j3 + 1] - vjn * ny;
+          const jvz = this.vel[j3 + 2] - vjn * nz;
+
+          this.vel[i3] = ivx + vjn * nx;
+          this.vel[i3 + 1] = ivy + vjn * ny;
+          this.vel[i3 + 2] = ivz + vjn * nz;
+          this.vel[j3] = jvx + vin * nx;
+          this.vel[j3 + 1] = jvy + vin * ny;
+          this.vel[j3 + 2] = jvz + vin * nz;
+        }
+      }
+    }
+  }
+
+  /** 時間 dt 分だけシミュレーションを進める。 */
+  step(dt)
+  {
+    const dtScaled = dt * this.speed;
+    for (let i = 0; i < this.count; i++)
+    {
+      const i3 = i * 3;
+      this.pos[i3] += this.vel[i3] * dtScaled;
+      this.pos[i3 + 1] += this.vel[i3 + 1] * dtScaled;
+      this.pos[i3 + 2] += this.vel[i3 + 2] * dtScaled;
+      this._reflect(i3);
+    }
+    this._collide();
+  }
+
+  /** InstancedMesh へ座標を反映する。 */
+  sync()
+  {
+    for (let i = 0; i < this.count; i++)
+    {
+      const i3 = i * 3;
+      this._dummy.position.set(this.pos[i3], this.pos[i3 + 1], this.pos[i3 + 2]);
+      this._dummy.rotation.y += 0.01;
+      this._dummy.updateMatrix();
+      this.mesh.setMatrixAt(i, this._dummy.matrix);
+    }
+    this.mesh.instanceMatrix.needsUpdate = true;
+  }
+}
+


### PR DESCRIPTION
## 概要
- 背景の球体物理を `BgPhysics` クラスとして新規追加
- `bg.js` をレンダリングとイベント処理中心の構造へ整理
- 物理設定をオブジェクト化し外部から注入可能に変更

## テスト
- `npm test` (package.json が存在せず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68aeab512b0c832ab584061792df0ea6