### PR TITLE
エントリースクリプトを src/entry に整理

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,9 @@
     }
   }
   </script>
-  <script type="module" src="./main.js"></script>
-  <script type="module" src="./bg.js"></script>
-  <script type="module" src="./works.js"></script>
+  <script type="module" src="./src/entry/avatar.js"></script>
+  <script type="module" src="./src/entry/background.js"></script>
+  <script type="module" src="./src/entry/works-gallery.js"></script>
 </body>
 
 </html>

--- a/src/entry/avatar.js
+++ b/src/entry/avatar.js
@@ -1,17 +1,17 @@
-// main.js
+// avatar.js
 // three.js アバター表示のエントリーポイント
 // - レンダラー・シーングラフ・操作系・ポスト処理を初期化
 // - ブートオーバーレイとリサイズ処理を管理
 import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
 
-import { CONFIG } from "./lib/config.js";
-import { createControls } from "./lib/controls.js";
-import { createPostPipeline } from "./lib/postprocess.js";
+import { CONFIG } from "../../lib/config.js";
+import { createControls } from "../../lib/controls.js";
+import { createPostPipeline } from "../../lib/postprocess.js";
 import { createRenderer,
-  fitToCanvas } from "./lib/renderer.js";
-import { createSceneGraph } from "./lib/scene.js";
-import { applyPS1Jitter, runFixedStepLoop } from "./lib/utils.js";
-import { initBootOverlay } from "./lib/bootOverlay.js";
+  fitToCanvas } from "../../lib/renderer.js";
+import { createSceneGraph } from "../../lib/scene.js";
+import { applyPS1Jitter, runFixedStepLoop } from "../../lib/utils.js";
+import { initBootOverlay } from "../../lib/bootOverlay.js";
 
 const canvas = document.getElementById("avatar-canvas");
 const renderer = createRenderer(THREE, canvas, CONFIG);

--- a/src/entry/background.js
+++ b/src/entry/background.js
@@ -1,12 +1,12 @@
-// bg.js
+// background.js
 // 背景アニメーション：立方体内で球が跳ね回るシンプルなデモ
 // - 既存の #bg-canvas 要素へ描画
 // - 壁との反射と球同士の弾性衝突を実装
 
 import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
-import { createRenderer, fitToCanvas } from "./lib/renderer.js";
-import { runFixedStepLoop } from "./lib/utils.js";
-import { BgPhysics } from "./lib/bgPhysics.js";
+import { createRenderer, fitToCanvas } from "../../lib/renderer.js";
+import { runFixedStepLoop } from "../../lib/utils.js";
+import { BgPhysics } from "../../lib/bgPhysics.js";
 
 const canvas = document.getElementById("bg-canvas");
 if (!canvas)

--- a/src/entry/works-gallery.js
+++ b/src/entry/works-gallery.js
@@ -1,7 +1,7 @@
-// works.js
+// works-gallery.js
 // 制作物ギャラリーのタブ切替と表示処理
 // WORKS データを別モジュールから読み込む
-import { WORKS } from './lib/data/works.js';
+import { WORKS } from '../../lib/data/works.js';
 
 const tabs = document.querySelectorAll('.works-tabs button');
 const image = document.querySelector('.works-image img');


### PR DESCRIPTION
## 概要
- エントリーポイントの JS ファイルを `src/entry` ディレクトリへ移動し名称を整理
- `index.html` のモジュール参照を新しいファイルへ更新
- ファイル移動に伴うインポートパスとコメントを調整

## テスト
- `npm test` (package.json が存在せず実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68aeaddbdf9c832abc6c11da59e93af0