### PR TITLE
three.js の読み込み方法を importmap へ統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,8 @@
   {
     "imports":
     {
-      "three": "https://unpkg.com/three@0.160.0/build/three.module.js"
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
     }
   }
   </script>

--- a/src/core/controls.js
+++ b/src/core/controls.js
@@ -1,6 +1,6 @@
 // src/core/controls.js
 // OrbitControls を薄くラップし、ズームやパンを禁止する
-import { OrbitControls } from "https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 
 /**
  * マウス操作用の OrbitControls を生成。

--- a/src/entry/avatar.js
+++ b/src/entry/avatar.js
@@ -2,7 +2,7 @@
 // three.js アバター表示のエントリーポイント
 // - レンダラー・シーングラフ・操作系・ポスト処理を初期化
 // - ブートオーバーレイとリサイズ処理を管理
-import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
+import * as THREE from "three";
 
 import { CONFIG } from "../core/config.js";
 import { createControls } from "../core/controls.js";

--- a/src/entry/background.js
+++ b/src/entry/background.js
@@ -3,7 +3,7 @@
 // - 既存の #bg-canvas 要素へ描画
 // - 壁との反射と球同士の弾性衝突を実装
 
-import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
+import * as THREE from "three";
 import { createRenderer, fitToCanvas } from "../core/renderer.js";
 import { runFixedStepLoop } from "../core/utils.js";
 import { BgPhysics } from "../core/bg-physics.js";


### PR DESCRIPTION
## 概要
- three.js の読み込みを CDN 直指定から importmap 利用へ変更
- OrbitControls を含む依存ファイルを同じ記法へ統一

## テスト
- `npm test` (package.json 不在のため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68af0d93c260832ab46528d386e1b63f