### PR TITLE
リサイズ処理を共通関数 setupResize に集約

### DIFF
--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -40,3 +40,29 @@ export function fitToCanvas(renderer, canvas, cfg)
     renderer.domElement.style.imageRendering = "";
   }
 }
+
+/**
+ * リサイズイベントを設定し、レンダラー・カメラ・ポスト処理を調整する。
+ * @param {THREE.WebGLRenderer} renderer 対象レンダラー
+ * @param {HTMLCanvasElement} canvas 対象キャンバス
+ * @param {THREE.Camera} camera 対象カメラ
+ * @param {object} cfg 設定値
+ * @param {{resize:function(THREE.WebGLRenderer):void}} [post] ポスト処理パイプライン
+ */
+export function setupResize(renderer, canvas, camera, cfg, post)
+{
+  function onResize()
+  {
+    fitToCanvas(renderer, canvas, cfg);
+    if (post && typeof post.resize === "function")
+    {
+      post.resize(renderer);
+    }
+    const rect = canvas.getBoundingClientRect();
+    camera.aspect = rect.width / rect.height;
+    camera.updateProjectionMatrix();
+  }
+
+  window.addEventListener("resize", onResize);
+  onResize();
+}

--- a/src/entry/avatar.js
+++ b/src/entry/avatar.js
@@ -7,8 +7,7 @@ import * as THREE from "three";
 import { CONFIG } from "../core/config.js";
 import { createControls } from "../core/controls.js";
 import { createPostPipeline } from "../core/postprocess.js";
-import { createRenderer,
-  fitToCanvas } from "../core/renderer.js";
+import { createRenderer, setupResize } from "../core/renderer.js";
 import { createSceneGraph } from "../core/scene.js";
 import { applyPS1Jitter, runFixedStepLoop } from "../core/utils.js";
 import { initBootOverlay } from "../core/boot-overlay.js";
@@ -22,18 +21,8 @@ const post = createPostPipeline(THREE, renderer, CONFIG); // { render(scene,came
 // ブートオーバーレイ初期化
 initBootOverlay();
 
-/**
- * Canvas サイズに合わせてレンダラー・ポスト処理・カメラを調整。
- */
-function resize()
-{
-  fitToCanvas(renderer, canvas, CONFIG);
-  post.resize(renderer);
-  camera.aspect = canvas.clientWidth / canvas.clientHeight;
-  camera.updateProjectionMatrix();
-}
-window.addEventListener("resize", resize);
-resize();
+// リサイズ処理の設定
+setupResize(renderer, canvas, camera, CONFIG, post);
 
 // ループ（PS1_MODE に合わせて分岐）
 const ROT_SPEED = 0.007 * 60;

--- a/src/entry/background.js
+++ b/src/entry/background.js
@@ -4,7 +4,7 @@
 // - 壁との反射と球同士の弾性衝突を実装
 
 import * as THREE from "three";
-import { createRenderer, fitToCanvas } from "../core/renderer.js";
+import { createRenderer, setupResize } from "../core/renderer.js";
 import { runFixedStepLoop } from "../core/utils.js";
 import { BgPhysics } from "../core/bg-physics.js";
 
@@ -86,13 +86,5 @@ runFixedStepLoop(
   }
 );
 
-// リサイズ
-function fit()
-{
-  fitToCanvas(renderer, canvas, cfg);
-  const rect = canvas.getBoundingClientRect();
-  camera.aspect = rect.width / rect.height;
-  camera.updateProjectionMatrix();
-}
-window.addEventListener("resize", fit);
-fit();
+// リサイズ処理の設定
+setupResize(renderer, canvas, camera, cfg);


### PR DESCRIPTION
## 概要
- リサイズ処理を `setupResize` に集約
- `avatar` と `background` の各エントリースクリプトで新関数を利用

## テスト
- `npm test` (package.json が無いため失敗するが実行のみ確認)


------
https://chatgpt.com/codex/tasks/task_e_68af0efef35c832a8869d9679f12a7d5