### PR TITLE
fix: three.js の CDN を切り替えて CORS エラーを解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,15 +84,15 @@
     </div>
   </div>
   
-  <script type="importmap">
-  {
-    "imports":
+    <script type="importmap">
     {
-      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+      "imports":
+      {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+      }
     }
-  }
-  </script>
+    </script>
   <script type="module" src="./src/entry/avatar.js"></script>
   <script type="module" src="./src/entry/background.js"></script>
   <script type="module" src="./src/entry/works-gallery.js"></script>


### PR DESCRIPTION
## 概要
- three.js の import map を unpkg から jsdelivr に切り替え
- CORS ヘッダ欠如による ExplodeModifier.js の読込失敗を解消

## テスト
- `npm test` (package.json 不在のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68af2ccc5d2c832a8b07b91cb3e81265