### PR TITLE
I と M のクリックで背景の球数を増減

### DIFF
--- a/src/entry/background.js
+++ b/src/entry/background.js
@@ -39,7 +39,8 @@ scene.add(amb, dir);
 // -------- 設定 --------
 const physicsCfg = {
   bounds: 4.0, // 立方体の一辺
-  count: 24, // 球の数（20〜40くらいが見栄えと負荷のバランス◎）
+  count: 24, // 初期の球の数（20〜40くらいが見栄えと負荷のバランス◎）
+  maxCount: 60, // 最大の球の数
   radius: 0.1, // 半径
   speed: 0.1, // 速度スケール
 };
@@ -59,7 +60,8 @@ const MAT = new THREE.MeshStandardMaterial({
   metalness: 0.1,
   roughness: 0.6,
 });
-const BALLS = new THREE.InstancedMesh(GEO, MAT, physicsCfg.count);
+const BALLS = new THREE.InstancedMesh(GEO, MAT, physicsCfg.maxCount);
+BALLS.count = physicsCfg.count;
 BALLS.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 scene.add(BALLS);
 
@@ -88,3 +90,16 @@ runFixedStepLoop(
 
 // リサイズ処理の設定
 setupResize(renderer, canvas, camera, cfg);
+
+/** 背景の球を増やす */
+export function increaseBalls()
+{
+  physics.addBall();
+}
+
+/** 背景の球を減らす */
+export function decreaseBalls()
+{
+  physics.removeBall();
+}
+

--- a/src/entry/title-tricks.js
+++ b/src/entry/title-tricks.js
@@ -1,6 +1,8 @@
 // title-tricks.js
 // h1 見出しの各文字に仕掛けを登録するモジュール
 
+import { increaseBalls, decreaseBalls } from './background.js';
+
 const titleElem = document.querySelector('main h1');
 const text = titleElem.textContent;
 titleElem.textContent = '';
@@ -98,4 +100,14 @@ registerTrick(4, () => {
       el.classList.remove('rotate');
     }, 5000);
   });
+});
+
+// 6 文字目 I の仕掛け登録: 背景の球を増やす
+registerTrick(5, () => {
+  increaseBalls();
+});
+
+// 7 文字目 M の仕掛け登録: 背景の球を減らす
+registerTrick(6, () => {
+  decreaseBalls();
 });


### PR DESCRIPTION
## 概要
- 背景物理に最大球数と増減処理を追加
- 背景モジュールから球数増減 API を公開
- タイトル文字 I/M のクリックで球数を増減

## テスト
- `npm test` : package.json 不在のためスクリプト未定義

------
https://chatgpt.com/codex/tasks/task_e_68af54894728832a9072c87a0a442c8a