### PR TITLE
10文字目Oクリックで背景を球体境界に変更

### DIFF
--- a/src/entry/title-tricks.js
+++ b/src/entry/title-tricks.js
@@ -1,7 +1,7 @@
 // title-tricks.js
 // h1 見出しの各文字に仕掛けを登録するモジュール
 
-import { increaseBalls, decreaseBalls } from './background.js';
+import { increaseBalls, decreaseBalls, switchToSphereMode } from './background.js';
 
 const titleElem = document.querySelector('main h1');
 const text = titleElem.textContent;
@@ -142,4 +142,9 @@ registerTrick(9, () => {
       }, 3000);
     }, i * interval);
   }
+});
+
+// 10 文字目 O の仕掛け登録: 背景の枠を球体に変更
+registerTrick(10, () => {
+  switchToSphereMode();
 });


### PR DESCRIPTION
## 概要
- h1の10文字目Oクリック時に背景を球体境界へ切り替え
- 切り替えに伴い群体形状を立方体へ変更
- 物理処理に球体境界を追加

## テスト
- `node --check src/core/bg-physics.js src/entry/background.js src/entry/title-tricks.js`
- `npm test` (package.json不在のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68af5f6897e4832abcb20c6d652fd6b5