### PR TITLE
エントリーポイントを統合しHTMLを整理

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SUNAGIMO HOUSE</title>
   <link href="https://db.onlinewebfonts.com/c/876f5b70a2a1304418e2e8b7479bf6da?family=PixelMplus10" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../style.css">
 </head>
 
 <body>
@@ -73,7 +73,7 @@
 
       <!-- ロゴ -->
       <div class="boot-logo">
-        <img src="img/logo.png" alt="" class="boot-mark" />
+        <img src="../img/logo.png" alt="" class="boot-mark" />
         <div class="boot-text">Sunagimo</div>
       </div>
 
@@ -97,10 +97,7 @@
 }
 </script>
 
-  <script type="module" src="./src/entry/avatar.js"></script>
-  <script type="module" src="./src/entry/background.js"></script>
-  <script type="module" src="./src/entry/works-gallery.js"></script>
-  <script type="module" src="./src/entry/title-tricks.js"></script>
+  <script type="module" src="../src/main.js"></script>
 </body>
 
 </html>

--- a/src/core/scene.js
+++ b/src/core/scene.js
@@ -18,7 +18,7 @@ export function createSceneGraph(THREE, cfg)
   const baseSize = 2.25;
   const geo = new THREE.BoxGeometry(baseSize, baseSize, baseSize);
 
-  const tex = new THREE.TextureLoader().load("img/me.jpg", t => {
+  const tex = new THREE.TextureLoader().load("../img/me.jpg", t => {
     t.colorSpace = THREE.SRGBColorSpace;
     if (cfg.PS1_MODE)
     {

--- a/src/data/works-data.js
+++ b/src/data/works-data.js
@@ -1,4 +1,4 @@
-// src/data/works.js
+// src/data/works-data.js
 // WORKS データを定義
 // 現状は日本語のみだが、将来的に多言語や JSON 取得へ拡張できる構造
 
@@ -6,7 +6,7 @@ export const WORKS = {
   ja: {
     game: [
       {
-        src: 'img/alien-chan.png',
+        src: '../img/alien-chan.png',
         alt: 'AlienChan',
         desc: [
           '作品1',
@@ -14,7 +14,7 @@ export const WORKS = {
         ]
       },
       {
-        src: 'img/me.jpg',
+        src: '../img/me.jpg',
         alt: 'me',
         desc: [
           '作品2',
@@ -24,7 +24,7 @@ export const WORKS = {
     ],
     tool: [
       {
-        src: 'img/logo.png',
+        src: '../img/logo.png',
         alt: 'ロゴ',
         desc: [
           '作品1',
@@ -34,7 +34,7 @@ export const WORKS = {
     ],
     other: [
       {
-        src: 'img/me.jpg',
+        src: '../img/me.jpg',
         alt: 'me',
         desc: [
           '自画像',

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,6 @@
+// main.js
+// エントリーポイント: 各モジュールをまとめて読み込む
+import './entry/avatar.js';
+import './entry/background.js';
+import './entry/works-gallery.js';
+import './entry/title-tricks.js';


### PR DESCRIPTION
## 概要
- main.jsを追加して各エントリーモジュールを一括読み込み
- public/index.htmlを作成しスクリプトタグを統合
- 画像パスを含む参照を新ディレクトリ構成に合わせて修正

## テスト
- `npm test` : パッケージ未定義のため実行不可（package.jsonなし）

------
https://chatgpt.com/codex/tasks/task_e_68af69415460832aae434af49fac462f