### PR TITLE
ライブラリとフォントのライセンス表記を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
 
   <footer>
     <p>&copy; 2025 Sunagimo  このサイトは VibeCoding で作成しました</p>
+    <p><a href="license.html">ライセンス表記</a></p>
   </footer>
 
   <!-- Boot Overlay: 起動時ロゴ -->

--- a/license.html
+++ b/license.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ライセンス</title>
+  <link href="https://db.onlinewebfonts.com/c/876f5b70a2a1304418e2e8b7479bf6da?family=PixelMplus10" rel="stylesheet">
+  <link rel="stylesheet" href="src/styles/base.css">
+  <link rel="stylesheet" href="src/styles/layout.css">
+</head>
+<body>
+  <main class="container">
+    <h1>ライセンス</h1>
+
+    <section>
+      <h2>ライブラリ</h2>
+      <p>本サイトでは以下のライブラリを使用しています。</p>
+      <ul>
+        <li><a href="https://threejs.org/" target="_blank" rel="noopener noreferrer">three.js</a> - <a href="https://unpkg.com/three@0.160.0/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a></li>
+        <li><a href="https://www.npmjs.com/package/three-subdivide" target="_blank" rel="noopener noreferrer">three-subdivide</a> - <a href="https://unpkg.com/three-subdivide@1.1.5/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>フォント</h2>
+      <p>本サイトでは以下のフォントを使用しています。</p>
+      <ul>
+        <li><a href="https://takwolf.github.io/PixelMplus/" target="_blank" rel="noopener noreferrer">PixelMplus10</a> - <a href="https://takwolf.github.io/PixelMplus/license.html" target="_blank" rel="noopener noreferrer">M+ FONTS License</a></li>
+      </ul>
+    </section>
+
+    <p><a href="index.html">トップへ戻る</a></p>
+  </main>
+</body>
+</html>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -11,9 +11,14 @@
 /* ===============================
    Footer
    =============================== */
-footer 
+footer
 {
   text-align: center;
   color: var(--muted);
   padding: 36px 8px;
+}
+
+footer a
+{
+  color: inherit;
 }


### PR DESCRIPTION
## 概要
- three.js、three-subdivide、PixelMplus10 のライセンスリンクを安定した CDN もしくは公式ページに変更

## テスト
- `npm test`（package.json が存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b01d202560832ab922af12123f0945